### PR TITLE
Removed epoch directory from archive convention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - pip install -q ${PRE} coveralls "pytest>=2.8" unittest2
 
 install:
-  - pip install -r requirements.txt
+  - pip install ${PRE} -r requirements.txt
   - python setup.py build
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
       - gfortran  # numpy/scipy
       - libblas-dev  # numpy/scipy
       - liblapack-dev  # numpy/scipy
-      - python-m2crypto  # glue
+      - swig  # m2crypto
 
 matrix:
   include:

--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -194,9 +194,15 @@ if args.executable is None:
     parser.error("Cannot find omicron.exe on path, please pass "
                  "--executable on the command line")
 
+# validate processing options
 if all((args.skip_root_merge, args.skip_ligolw_add, args.skip_gzip,
         not args.archive)):
     args.skip_postprocessing = True
+if args.archive:
+    argsd = vars(args)
+    for arg in ['skip-root-merge', 'skip-ligolw-add', 'skip-gzip']:
+        if argsd[arg.replace('-', '_')]:
+            parser.error("Cannot use --%s with --archive" % arg)
 
 ifo = args.ifo
 llhoft = data.ligo_low_latency_hoft_type(ifo)

--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -79,7 +79,7 @@ except ImportError:
     import ConfigParser as configparser
 
 from glue import pipeline
-from glue.lal import CacheEntry
+from glue.lal import (Cache, CacheEntry)
 
 from omicron import (const, segments, log, data, parameters, utils, condor, io)
 
@@ -674,6 +674,7 @@ for s, e in segs:
 
                         # add rm jobs
                         print('rm -f %s %s' % (roots, xmls), file=f)
+
             ppnode = pipeline.CondorDAGNode(ppjob)
             ppnode.add_var_arg(script)
             ppnode.set_category('postprocessing')
@@ -688,13 +689,32 @@ for s, e in segs:
 # do all archiving last, once all post-processing has completed
 if args.archive:
     archivenode = pipeline.CondorDAGNode(archivejob)
+    xmlcache = Cache()
+    rootcache = Cache()
     if not args.rescue:
+        # write shell script to seed archive
         with open(archivejob.get_executable(), 'w') as f:
             print('#!/bin/bash -e\n', file=f)
             for gpsdir, filelist in archivefiles.iteritems():
+                # write 'mv' op to script
                 print("mkdir -p %s" % gpsdir, file=f)
                 print("mv %s %s" % (' '.join(filelist), gpsdir), file=f)
-    os.chmod(archivejob.get_executable(), 0o755)
+                # record archived files in caches
+                filenames = [os.path.join(gpsdir, os.path.basename(x)) for
+                             x in filelist]
+                xmlcache.extend(CacheEntry.from_T050017(x) for x in filenames
+                                if x.endswith('xml.gz'))
+                rootcache.extend(CacheEntry.from_T050017(x) for x in filenames
+                                if x.endswith('root'))
+        os.chmod(archivejob.get_executable(), 0o755)
+        # write caches to disk
+        xmlcachefile = os.path.join(cachedir, 'omicron-xml.lcf')
+        data.write_cache(xmlcache, xmlcachefile)
+        logger.debug("XML cache written to %s" % xmlcachefile)
+        rootcachefile = os.path.join(cachedir, 'omicron-root.lcf')
+        data.write_cache(rootcache, rootcachefile)
+        logger.debug("ROOT cache written to %s" % rootcachefile)
+    # add node to DAG
     for node in ppnodes:
         archivenode.add_parent(node)
     archivenode.set_category('archive')

--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -644,8 +644,7 @@ for s, e in segs:
                         # add archive
                         if args.archive:
                             x = CacheEntry.from_T050017(xml)
-                            epoch = const.epoch_at_gps(x.segment[0])
-                            target = os.path.join(const.OMICRON_ARCHIVE, epoch,
+                            target = os.path.join(const.OMICRON_ARCHIVE,
                                                   x.observatory,
                                                   x.description,
                                                   str(int(x.segment[0]))[:5])

--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -81,7 +81,7 @@ except ImportError:
 from glue import pipeline
 from glue.lal import CacheEntry
 
-from omicron import (const, segments, log, data, parameters, utils, condor)
+from omicron import (const, segments, log, data, parameters, utils, condor, io)
 
 logger = log.Logger('omicron-process')
 
@@ -208,10 +208,19 @@ ifo = args.ifo
 llhoft = data.ligo_low_latency_hoft_type(ifo)
 group = args.group
 online = args.gps is None
+
+# format file-tag
 filetag = args.file_tag
-if filetag and not filetag.startswith('_'):
+if filetag:
+    filetag = re.sub('[:_\s-]', '_', filetag).rstrip('_').strip('_')
+    if const.OMICRON_FILETAG.lower() in filetag.lower():
+        afiletag = filetag
+    else:
+        afiletag = '%s_%s' % (filetag, const.OMICRON_FILETAG.upper())
     filetag = '_%s' % filetag
-filetag = re.sub('[:_\s-]', '_', filetag.upper())
+else:
+    filetag = ''
+    afiletag = const.OMICRON_FILETAG.upper()
 
 logger.info("--- Welcome to the Omicron processor ---")
 
@@ -614,34 +623,43 @@ for s, e in segs:
                     print('#!/bin/bash -e\n', file=f)
                     # build post-processing nodes for each channel
                     for c in chanlist:
-                        print("# %s" % c, file=f)
+                        print("# %s" % c, file=f)  # comment header for sh
+
+                        # work out filenames for coalesced files
                         chandir = os.path.join(rundir, 'triggers', c)
                         cname = re.sub('[:_-]', '_', c).replace('_', '-', 1)
+                        target, filename = os.path.split(
+                            io.get_archive_filename(
+                                c, ts, td, filetag=afiletag, ext='root'))
+
+                        # list of all root files
                         roots = ' '.join(
-                            os.path.join(chandir,
-                                         '%s_%d_%d.root' % (c, fs, fe-fs))
+                            os.path.join(
+                                chandir, '%s_%d_%d.root' % (c, fs, fe-fs))
                             for (fs, fe) in filesegments)
+                        # list of all xmls
+                        xmls = ' '.join(
+                            os.path.join(chandir, '%s_%s-%d-%d.xml' % (
+                                cname, const.OMICRON_FILETAG, fs, fe-fs))
+                            for (fs, fe) in filesegments)
+
                         # add omicron-root-merge
                         if args.skip_root_merge:
                             root = roots
                         else:
-                            root = os.path.join(
-                                chandir, '%s%s_Omicron-%d-%d.root'
-                                         % (cname, filetag, ts, td))
+                            root = os.path.join(chandir, filename)
                             print('%s %s %s --strict'
                                   % (rootmerge, roots, root), file=f)
+
                         # add ligolw_add
-                        xmls = ' '.join(os.path.join(
-                            chandir, '%s_Omicron-%d-%d.xml' % (cname, fs, fe-fs))
-                            for (fs, fe) in filesegments)
                         if args.skip_ligolw_add:
                             xml = xmls
                         else:
-                            xml = os.path.join(
-                                chandir, '%s%s_Omicron-%d-%d.xml'
-                                         % (cname, filetag, ts, td))
+                            xml = os.path.join(chandir,
+                                               filename.replace('root', 'xml'))
                             print('%s %s --output %s'
                                   % (ligolw_add, xmls, xml), file=f)
+
                         # add gzip
                         if not args.skip_gzip:
                             print('%s --force %s' % (gzip, xml), file=f)
@@ -649,11 +667,6 @@ for s, e in segs:
 
                         # add archive
                         if args.archive:
-                            x = CacheEntry.from_T050017(xml)
-                            target = os.path.join(const.OMICRON_ARCHIVE,
-                                                  x.observatory,
-                                                  x.description,
-                                                  str(int(x.segment[0]))[:5])
                             try:
                                 archivefiles[target].extend([xml, root])
                             except KeyError:

--- a/omicron/const.py
+++ b/omicron/const.py
@@ -23,7 +23,7 @@ import os
 
 from glue.segments import segment as Segment
 
-# generic parameters
+# -- generic parameters
 try:
     IFO = os.environ['IFO']
 except KeyError:
@@ -45,10 +45,13 @@ else:
 SITE = os.getenv('SITE')
 site = os.getenv('site', SITE and SITE.lower() or None)
 
-# omicron directories
+# -- omicron directories
 HOME = os.path.expanduser('~')
+# where Omicron runs
 OMICRON_BASE = os.path.join(HOME, 'Omicron')
+# where Omicron triggers are produced
 OMICRON_PROD = os.path.join(OMICRON_BASE, 'Prod')
+# archive storage directory
 OMICRON_ARCHIVE = os.path.join(HOME, 'triggers')
 # tag Omicron itself places on XML files
 OMICRON_FILETAG = 'Omicron'

--- a/omicron/const.py
+++ b/omicron/const.py
@@ -50,6 +50,8 @@ HOME = os.path.expanduser('~')
 OMICRON_BASE = os.path.join(HOME, 'Omicron')
 OMICRON_PROD = os.path.join(OMICRON_BASE, 'Prod')
 OMICRON_ARCHIVE = os.path.join(HOME, 'triggers')
+# tag Omicron itself places on XML files
+OMICRON_FILETAG = 'Omicron'
 
 # omicron production version
 OMICRON_VERSION = 'v2r1'

--- a/omicron/io.py
+++ b/omicron/io.py
@@ -22,10 +22,14 @@
 import warnings
 import os.path
 import glob
+import re
 
 from glue.lal import Cache
 
+from . import const
 from .segments import (Segment, segmentlist_from_tree)
+
+re_delim = re.compile('[:_-]')
 
 
 def merge_root_files(inputfiles, outputfile,
@@ -160,3 +164,54 @@ def find_pending_files(channel, proddir, ext='xml.gz'):
     """
     g = os.path.join(proddir, 'triggers', channel, '*.%s' % ext)
     return Cache.from_urls(glob.iglob(g))
+
+
+def get_archive_filename(channel, start, duration, ext='xml.gz',
+                         filetag=const.OMICRON_FILETAG.upper(),
+                         archive=const.OMICRON_ARCHIVE):
+    """Returns the full file path for this channel's triggers
+
+    This method will design a trigger file path for you, rather than find
+    a file that is already there, and so should be used to seed an archive,
+    not search it.
+
+    Parameters
+    ----------
+    channel : `str`
+        name of channel
+    start : `int`
+        GPS start time of file
+    duration : `int`
+        duration (seconds) of file
+    ext : `str`, optional
+        file extension, defaults to ``xml.gz``
+    filetag : `str`, optional
+        filetag to be appended after the channel name, defaults to ``OMICRON``
+    archive : `str`, optional
+        base directory of the trigger archive, defaults to
+        `const.OMICRON_ARCHIVE`
+
+    Returns
+    -------
+    filepath : `str`
+        the absolute path where this file should be stored
+
+    See Also
+    --------
+    `T050017 <https://dcc.ligo.org/LIGO-T050017>`_ for details of the
+    file-naming convention.
+
+    Examples
+    --------
+    >>> get_archive_filename('H1:GDS-CALIB_STRAIN', 1234567890, 100, archive='/triggers')
+    '/triggers/H1/GDS_CALIB_STRAIN_OMICRON/12345/H1-GDS_CALIB_STRAIN_OMICRON-1234567890-100.xml.gz'
+
+    """
+    cname = re_delim.sub('_', str(channel))
+    ifo, description = cname.split('_', 1)
+    if filetag is not None:
+        description += '_%s' % re_delim.sub('_', filetag).strip('_')
+    filename = '%s-%s-%d-%d.%s' % (
+        ifo, description, int(start), int(duration), ext)
+    gps5 = str(int(start))[:5]
+    return os.path.join(archive, ifo, description, gps5, filename)

--- a/omicron/io.py
+++ b/omicron/io.py
@@ -213,5 +213,8 @@ def get_archive_filename(channel, start, duration, ext='xml.gz',
         description += '_%s' % re_delim.sub('_', filetag).strip('_')
     filename = '%s-%s-%d-%d.%s' % (
         ifo, description, int(start), int(duration), ext)
-    gps5 = str(int(start))[:5]
+    if start < 10000:
+        gps5 = '%.5d' % int(start)
+    else:
+        gps5 = str(int(start))[:5]
     return os.path.join(archive, ifo, description, gps5, filename)

--- a/omicron/tests/test_io.py
+++ b/omicron/tests/test_io.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2016)
+#
+# This file is part of PyOmicron.
+#
+# PyOmicron is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PyOmicron is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyOmicron.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for omicron.io
+"""
+
+from compat import unittest
+
+from omicron import (io, const)
+
+
+class IoTestCase(unittest.TestCase):
+    def test_get_archive_filename(self):
+        self.assertEqual(
+            io.get_archive_filename('L1:GDS-CALIB_STRAIN', 0, 100),
+            '%s/L1/GDS_CALIB_STRAIN_OMICRON/00000/'
+            'L1-GDS_CALIB_STRAIN_OMICRON-0-100.xml.gz' % const.OMICRON_ARCHIVE)
+        self.assertEqual(
+            io.get_archive_filename('L1:GDS-CALIB_STRAIN', 1234567890, 123,
+                                    archive='/triggers', filetag='TEST-TAg',
+                                    ext='root'),
+            '/triggers/L1/GDS_CALIB_STRAIN_TEST_TAg/12345/'
+            'L1-GDS_CALIB_STRAIN_TEST_TAg-1234567890-123.root')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 numpy
+M2Crypto
+pykerberos
+python-cjson
 http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
+http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
 gwpy


### PR DESCRIPTION
This PR fixes #5 by removing the epoch name from the directory-naming convention for the trigger archive.

This is mainly achieved by introducing a new method `omicron.io.get_archive_filename` which builds the filename for a given channel, and GPS segment, which is used in `omicron-process` to name the coalesced XML and ROOT files.