### PR TITLE
Preserve all metadata when merging ROOT files

### DIFF
--- a/bin/omicron-root-merge
+++ b/bin/omicron-root-merge
@@ -31,10 +31,6 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('filename', nargs='+', help='file to merge')
 parser.add_argument('output', help='output file name')
-parser.add_argument('-m', '--keep-all-metadata', action='store_true',
-                    default=False,
-                    help='preserve all metadata, default: %(default)s '
-                         '(keep metadata for first file')
 parser.add_argument('-d', '--remove-input', action='store_true', default=False,
                     help='remove input files after writing output, '
                          'default: %(default)s')
@@ -42,8 +38,7 @@ parser.add_argument('-s', '--strict', action='store_true', default=False,
                     help='only merge contiguous data, default: %(default)s')
 
 args = parser.parse_args()
-io.merge_root_files(args.filename, args.output, strict=args.strict,
-                    all_metadata=args.keep_all_metadata)
+io.merge_root_files(args.filename, args.output, strict=args.strict)
 
 # remove input files
 if args.remove_input:

--- a/omicron/io.py
+++ b/omicron/io.py
@@ -34,7 +34,7 @@ re_delim = re.compile('[:_-]')
 
 def merge_root_files(inputfiles, outputfile,
                      trees=['segments', 'triggers', 'metadata'],
-                     all_metadata=False, strict=True, on_missing='raise'):
+                     strict=True, on_missing='raise'):
     """Merge several ROOT files into a single file
 
     Parameters
@@ -45,9 +45,6 @@ def merge_root_files(inputfiles, outputfile,
         the path of the output ROOT file to write
     tree : `list` of `str`
         the names of the ROOT Trees to include
-    all_metadata : `bool`, default: `False`
-        whether to include metadata from all files, or just the first one
-        (default)
     strict : `bool`, default: `True`
         only combine contiguous files (as described by the contained segmenets)
     """
@@ -67,14 +64,8 @@ def merge_root_files(inputfiles, outputfile,
 
     for tree in trees:
         chains[tree] = ROOT.TChain(tree)
-        if tree == 'metadata' and not all_metadata:
-            try:
-                chains[tree].Add(inputfiles[0])
-            except IndexError:
-                pass
-        else:
-            for i, f in enumerate(inputfiles):
-                chains[tree].Add(f)
+        for i, f in enumerate(inputfiles):
+            chains[tree].Add(f)
         if (strict and tree == 'segments' and
                 len(segmentlist_from_tree(chains[tree]).coalesce()) > 1):
             raise RuntimeError("Cannot perform a 'strict' merge on files "


### PR DESCRIPTION
This PR fixes #8 by removing the options to preserve only the metadata from the first ROOT file from `omicron.io.merge_root_files` and the `omicron-root-merge` executable.