### PR TITLE
Fixed ValueError in omicron-status when no state segments

### DIFF
--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -266,7 +266,11 @@ except IndexError:
 segs = segs.contract(padding)
 # get list of segment starts and ends, to work in which data are missing
 # or just artefacts of the padding
-starts, ends = zip(*segs)
+try:
+    starts, ends = zip(*segs)
+except ValueError:
+    starts = []
+    ends = []
 
 # load archive latency
 latencyfile = os.path.join(outdir, 'nagios-latency-%s.hdf' % tag)


### PR DESCRIPTION
This PR fixes a bug in `omicron-status` that would raise a `ValueError` when trying to unzip an empty state segment list.