### PR TITLE
Set default FFTPLAN as FFTW_ESTIMATE for Omicron v2r2

### DIFF
--- a/omicron/parameters.py
+++ b/omicron/parameters.py
@@ -137,11 +137,14 @@ def generate_parameters_files(config, section, cachefile, rundir,
 
     # set segment parameters for this omicron version
     if omicron_version >= 'v2r2':
+        # re-structure timing parameters
         params['PARAMETER']['PSDLENGTH'] = (
             params['PARAMETER'].pop('CHUNKDURATION'))
         params['PARAMETER']['TIMING'] = '%s %s' % (
             params['PARAMETER'].pop('SEGMENTDURATION'),
             params['PARAMETER'].pop('OVERLAPDURATION'))
+        # add FFT parameters
+        params['PARAMETER'].setdefault('FFTPLAN', 'FFTW_ESTIMATE')
 
     # write files
     parfiles = []


### PR DESCRIPTION
This PR sets the default `FFTPLAN` parameter for Omicron v2r2 as `FFTW_ESTIMATE`. @FlorentRobinet has advised this to be better for processing small numbers of chunks, so you spend more time running FFTs, but less this working out a plan at the beginning.

This isn't exposed to the user in a useful way just yet.