### PR TITLE
Fixed NameError in omicron-process if all frames missing

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -527,6 +527,7 @@ if not online and len(cache) == 0:
 try:
     cachesegs = (segments.cache_segments(cache) & dataspan).coalesce()
 except TypeError:
+    cachesegs = Cache()
     alldata = False
 else:
     alldata = cachesegs == dataspan


### PR DESCRIPTION
This PR fixes #20 by setting `cachesegs = Cache()` if no frames are found for the data interval.