### PR TITLE
Always write segments.txt file

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -579,11 +579,6 @@ for seg in trigsegs:
     logger.info("    %d %d" % seg)
 logger.info("Duration = %d seconds" % abs(trigsegs))
 
-# write segments to tmpfile
-segtmp = '%s.tmp' % os.path.splitext(segfile)[0]
-segments.write_segments(span, segtmp)
-logger.info("Segments written to\n%s" % segtmp)
-
 # -- make parameters files then generate the DAG ------------------------------
 
 # generate a 'master' parameters.txt file for archival purposes
@@ -775,7 +770,6 @@ if args.archive:
                                 if x.endswith('xml.gz'))
                 rootcache.extend(CacheEntry.from_T050017(x) for x in filenames
                                 if x.endswith('root'))
-            print('\nmv %s %s' % (segtmp, segfile), file=f)
         os.chmod(archivejob.get_executable(), 0o755)
         # write caches to disk
         xmlcachefile = os.path.join(cachedir, 'omicron-xml.lcf')
@@ -869,6 +863,10 @@ try:
         tempfiles.extend(files)
 except RuntimeError:
     pass
+
+# write segments
+segments.write_segments(span, segfile)
+logger.info("Segments written to\n%s" % segfile)
 
 # archive files
 stub = '%d-%d' % (start, end)

--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -798,6 +798,11 @@ else:
     logger.info("Dag with %d nodes written to" % len(dag.get_nodes()))
 print(os.path.abspath(dagfile))
 
+# write segments now
+# this means that online processing will _always_ move on, even if it fails
+segments.write_segments(span, segfile)
+logger.info("Segments written to\n%s" % segfile)
+
 if args.no_submit:
     sys.exit(0)
 
@@ -863,10 +868,6 @@ try:
         tempfiles.extend(files)
 except RuntimeError:
     pass
-
-# write segments
-segments.write_segments(span, segfile)
-logger.info("Segments written to\n%s" % segfile)
 
 # archive files
 stub = '%d-%d' % (start, end)

--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -445,13 +445,15 @@ h5file.close()
 # write nagios output for files
 status = []
 for segset, tag in zip([gaps, overlap], ['gaps', 'overlap']):
-    chans = [c for c in segset if abs(operator.or_(*segset[c].values()))]
+    chans = [(c, segset[c]) for c in segset
+             if abs(operator.or_(*segset[c].values()))]
     jsonfp = os.path.join(outdir, 'nagios-%s-%s.json' % (tag, group))
     status.append((tag, jsonfp))
     if chans:
+        gapstr = '\n'.join('%s: %s' % c for c in chans)
         code = 1
-        message = ("%s found in Omicron files for group %r\nChannels: %s"
-                   % (tag.title(), group, ' '.join(chans)))
+        message = ("%s found in Omicron files for group %r\n%s"
+                   % (tag.title(), group, gapstr))
     else:
         code = 0
         message = "No %s found in Omicron files for group %r" % (tag, group)


### PR DESCRIPTION
This PR modifies `omicron-process` to _always_ write the `segments.txt` file, even in the analysis fails. This means that an online analysis will _always_ move on to the next segment, and won't get hung up on one broken chunk.