### PR TITLE
Added verbosity to omicron-status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
 before_install:
   - pip install -q --upgrade pip
   - pip install -q ${PRE} coveralls "pytest>=2.8" unittest2
+  # need to install astropy 1.1 specifically for py26
+  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
 
 install:
   - pip install ${PRE} -r requirements.txt

--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -68,12 +68,17 @@ grid = GridSpec(2, 1)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
+logger = log.Logger('omicron-status')
+
 NOW = to_gps('now').seconds
 
 try:
     omicronversion = str(get_omicron_version())
 except KeyError:
     omicronversion = 'Unknown'
+    logger.warning("Omicron version unknown")
+else:
+    logger.info("Found omicron version: %s" % omicronversion)
 
 # -- parse command line
 parser = argparse.ArgumentParser(description=__doc__)
@@ -135,6 +140,9 @@ if args.ifo is None:
                  "please pass --ifo on the command line")
 
 group = args.group
+
+logger.info("Checking status for %r group" % group)
+
 archive = args.archive_directory
 proddir = args.production_directory.format(group=args.group)
 outdir = args.output_directory
@@ -145,10 +153,14 @@ filetypes = ['xml.gz', 'root']
 if not os.path.isdir(outdir):
     os.makedirs(outdir)
 
+logger.debug("Set output directory to %s" % outdir)
+logger.debug("Will process the following filetypes: %s" % ", ".join(filetypes))
+
 # -- parse configuration file and get parameters ------------------------------
 
 cp = configparser.ConfigParser()
 cp.read(args.config_file)
+logger.info("Configuration read")
 
 # validate
 if not cp.has_section(group):
@@ -164,6 +176,7 @@ channels = args.channel
 if not channels:
     channels = [c.split()[0] for
                 c in cp.get(group, 'channels').strip('\n').split('\n')]
+logger.debug("Found %d channels" % len(channels))
 
 start = args.gps_start_time
 end = args.gps_end_time
@@ -174,7 +187,10 @@ try:
     stateflag = cp.get(group, 'state-flag')
 except configparser.NoOptionError:
     stateflag = None
+else:
+    logger.debug("Parsed state flag: %r" % stateflag)
 
+logger.info("Processing %d-%d" % (start, end))
 
 # -- define nagios JSON printer -----------------------------------------------
 
@@ -207,11 +223,13 @@ def print_nagios_json(code, message, outfile, tag='status'):
     }
     with open(outfile, 'w') as f:
         f.write(json.dumps(out))
+    logger.debug("nagios info written to %s" % outfile)
 
 
 # -- get condor status --------------------------------------------------------
 
 if not args.skip_condor:
+    logger.info("-- Checking condor status --")
     # connect to scheduler
     schedd = htcondor.Schedd()
 
@@ -222,6 +240,7 @@ if not args.skip_condor:
         # check manager status
         jobs = schedd.query('OmicronManager == "%s" && Owner == "%s"'
                             % (group, args.user), ['JobStatus'])
+        logger.debug("Found %d manager jobs" % len(jobs))
         if len(jobs) > 1:
             raise RuntimeError("Multiple OmicronManager jobs found for %r"
                                % group)
@@ -231,9 +250,11 @@ if not args.skip_condor:
         if status not in okstates:
             raise RuntimeError("OmicronManager status for %r: %r"
                                % (group, status))
+        logger.debug("Manager status is %r" % status)
         # check node status
         jobs = schedd.query('OmicronProcess == "%s" && Owner == "%s"'
                             % (group, args.user), ['JobStatus', 'ClusterId'])
+        logger.debug("Found %d nodes running" % len(jobs))
         for job in jobs:
             status = condor.JOB_STATUS[job['JobStatus']]
             if status not in okstates:
@@ -241,9 +262,11 @@ if not args.skip_condor:
                                    % (job['ClusterId'], group, status))
     except RuntimeError as e:
         print_nagios_json(2, str(e), jsonfp, tag='condor')
+        logger.warning("Failed to determine condor status: %r" % str(e))
     else:
         print_nagios_json(0, "Condor processing for %r is OK" % group, jsonfp,
                           tag='condor')
+        logger.info("Condor processing is OK")
 
     # get job duration history
     plot = TimeSeriesPlot(figsize=[12, 3])
@@ -251,10 +274,14 @@ if not args.skip_condor:
     ax = plot.gca()
     times, jobdur = condor.get_job_duration_history_shell(
         'OmicronProcess', group, maxjobs=5000)
+    logger.debug("Recovered duration history for %d omicron.exe jobs"
+                 % len(times))
     l = ax.plot([0], [1], label='Omicron.exe')[0]
     ax.plot(times, jobdur, linestyle=' ', marker='.', color=l.get_color())
     times, jobdur = condor.get_job_duration_history_shell(
         'OmicronPostProcess', group, maxjobs=5000)
+    logger.debug("Recovered duration history for %d post-processing jobs"
+                 % len(times))
     l = ax.plot([0], [1], label='Post-processing')[0]
     ax.plot(times, jobdur, linestyle=' ', marker='.', color=l.get_color())
     ax.legend(loc='upper left', borderaxespad=0, bbox_to_anchor=(1.01, 1),
@@ -265,13 +292,17 @@ if not args.skip_condor:
     ax.set_title('Omicron job durations for %r' % group)
     ax.set_ylabel('Job duration [seconds]')
     ax.xaxis.labelpad = 5
-    plot.save(os.path.join(outdir, 'nagios-condor-%s.png' % group))
+    png = os.path.join(outdir, 'nagios-condor-%s.png' % group)
+    plot.save(png)
     plot.close()
+    logger.debug("Saved condor plot to %s" % png)
 
 if args.skip_file_checks:
     sys.exit(0)
 
 # -- get file latency and archive completeness --------------------------------
+
+logger.info("-- Checking file archive --")
 
 # get state segments
 if stateflag is None:
@@ -282,8 +313,11 @@ try:
     end = segs[-1][1]
 except IndexError:
     pass
+
 # apply inwards padding to generate resolvable segments
 segs = segs.contract(padding)
+logger.debug("Found %d seconds of analysable time" % abs(segs))
+
 # get list of segment starts and ends, to work in which data are missing
 # or just artefacts of the padding
 try:
@@ -306,6 +340,7 @@ if os.path.isfile(latencyfile):
                 except KeyError:
                     times[c][ft] = numpy.ndarray((0,))
                     ldata[c][ft] = numpy.ndarray((0,))
+    logger.debug("Parsed latency data from %s" % latencyfile)
 else:
     for c in channels:
         for ft in filetypes:
@@ -327,6 +362,7 @@ leg['Overlapping'] = SegmentAxes.build_segment([0, 1], 0, facecolor='yellow',
 leg['Pending'] = SegmentAxes.build_segment([0, 1], 0, facecolor='lightskyblue',
                                            edgecolor='blue')
 
+logger.debug("Checking archive for each channel...")
 
 # find files
 latency = {}
@@ -430,6 +466,7 @@ for c in channels:
         outdir, 'nagios-latency-%s.png' % c.replace(':', '-'))
     plot.save(png)
     plot.close()
+    logger.debug("    %s" % c)
 
 # update latency and write archive
 h5file = h5py.File(latencyfile, 'w')
@@ -440,6 +477,7 @@ for c in channels:
         for ft in filetypes:
             g2.create_dataset(ft, data=d[ft], compression='gzip')
 h5file.close()
+logger.debug("Stored latency data as HDF in %s" % latencyfile)
 
 # write nagios output for files
 status = []
@@ -569,3 +607,4 @@ if args.html:
     });""", type="text/javascript")
     with open(os.path.join(outdir, 'index.html'), 'w') as f:
         f.write(str(page))
+    logger.debug("HTML summary written to %s" % f.name)

--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -47,13 +47,12 @@ from matplotlib.gridspec import GridSpec
 import h5py
 
 from glue import markup
-from glue.lal import Cache
 
 from gwpy.time import to_gps
-from gwpy.segments import (Segment, SegmentList, DataQualityFlag)
+from gwpy.segments import Segment
 from gwpy.plotter import (rcParams, TimeSeriesPlot, SegmentAxes)
 
-from omicron import (condor, const, io, nagios, segments, __version__)
+from omicron import (condor, const, io, log, segments, __version__)
 from omicron.utils import get_omicron_version
 
 rcParams.update({

--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -109,6 +109,9 @@ parser.add_argument('-A', '--skip-condor', action='store_true',
 parser.add_argument('-B', '--skip-file-checks', action='store_true',
                     default=False,
                     help="don't check file status, default: %(default)s")
+parser.add_argument('-C', '--skip-job-duration', action='store_true',
+                    default=False, help="don't query and plot job durations, "
+                                        "default: %(default)s")
 
 pout = parser.add_argument_group('Output options')
 pout.add_argument('--json', const=True, nargs='?', default=False,
@@ -268,6 +271,7 @@ if not args.skip_condor:
                           tag='condor')
         logger.info("Condor processing is OK")
 
+if not args.skip_job_duration:
     # get job duration history
     plot = TimeSeriesPlot(figsize=[12, 3])
     plot.subplots_adjust(bottom=.22, top=.87)


### PR DESCRIPTION
This PR adds verbose logging to the `omicron-status` utility, mainly for debugging purposes.

Also, I added a new `-C/--skip-job-duration` command-line option to skip querying the condor history for job durations, which takes forever.