### PR TITLE
Ignore missing frames when determining 'all data'

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -554,7 +554,7 @@ except TypeError:
     cachesegs = type(dataspan)()
     alldata = False
 else:
-    alldata = cachesegs == dataspan
+    alldata = cachesegs[-1][1] >= dataspan[-1][1]
 
 # write cache
 if not os.path.isdir(cachedir):
@@ -572,7 +572,7 @@ segs = (cachesegs & segs).coalesce()
 
 # if all of the data are available, but no segments, record segments.txt
 if newdag and len(segs) == 0 and online and alldata:
-    logger.info("No segments found, but all data are available. "
+    logger.info("No segments found, but up-to-date data are available. "
                 "A segments.txt file will be written so we don't have to "
                 "search these data again")
     segments.write_segments(cachesegs, segfile)


### PR DESCRIPTION
This PR modifies the check that 'all data' are available. This check is used to record that a certain chunk of time has been checked for state segments, and that none were found, but currently fails when there is a missing frame. This means that during extended periods of no operations, the segment to be checked grows continuously.

The check is now that the most recent available data file is up-to-date. This will in general mean that more gaps are created, but those can be filled in after-the-fact.