### PR TITLE
Improved check whether DAG is already running

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -392,10 +392,12 @@ if not os.path.isdir(condir):
     os.makedirs(condir)
 
 # check dagman lock file
-if os.path.isfile(os.path.join(condir, 'omicron.dag.lock')) and args.reattach:
-     logger.info('omicron.dag.lock found in %s, will reattach' % rundir)
-elif os.path.isfile(os.path.join(condir, 'omicron.dag.lock')):
-    raise RuntimeError("omicron.dag.lock found in %s, DAG already running"
+running = condor.dag_is_running(os.path.join(condir, 'omicron.dag'), group):
+if running and args.reattach:
+     logger.info('Detected omicron.dag already running %s, will reattach'
+                 % rundir)
+elif running:
+    raise RuntimeError("Detector omicron.dag in %s is already running"
                        % rundir)
 else:
      args.reattach = False


### PR DESCRIPTION
This PR introduces a more robust way of testing whether a DAG has already been submitted for a given channel group. It's not quite enough just to test for a `dag.lock` file, mainly if condor hasn't actually started the scheduler `condor_dagman` job yet.