### PR TITLE
Wait until DAGMan is running before watching

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -392,7 +392,7 @@ if not os.path.isdir(condir):
     os.makedirs(condir)
 
 # check dagman lock file
-running = condor.dag_is_running(os.path.join(condir, 'omicron.dag'), group):
+running = condor.dag_is_running(os.path.join(condir, 'omicron.dag'), group)
 if running and args.reattach:
      logger.info('Detected omicron.dag already running %s, will reattach'
                  % rundir)

--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -78,6 +78,8 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
+import htcondor
+
 from glue import pipeline
 from glue.lal import (Cache, CacheEntry)
 
@@ -851,7 +853,7 @@ for i in range(args.submit_rescue_dag + 1):
     if args.reattach:  # find ID of existing DAG
         dagid = condor.find_dagman_id(group, classad="OmicronDAGMan")
         logger.info("Found existing condor ID = %d" % dagid)
-    else:
+    else:  # or submit DAG
         dagmanargs = set()
         dagmanopts = {'-append': '+OmicronDAGMan=\"%s\"' % group}
         for x in args.dagman_option:
@@ -864,6 +866,21 @@ for i in range(args.submit_rescue_dag + 1):
                 dagmanopts[key] = val
         dagid = condor.submit_dag(dagfile, *list(dagmanargs), **dagmanopts)
         logger.info("Condor ID = %d" % dagid)
+    # wait for DAG to be in running state
+    schedd = htcondor.Schedd()
+    stat = condor.get_job_status(dagid, schedd)
+    while stat != condor.JOB_STATUS_MAP['running']:
+        logger.debug('Waiting for DAG to enter R state...')
+        dagmansleep = True
+        if stat > condor.JOB_STATUS_MAP['running']:
+            raise RuntimeError("DAGMan process %s is not in a good state"
+                               % dagid)
+        sleep(2)
+        stat = condor.get_job_status(dagid, schedd)
+    else:
+        dagmansleep = False
+    # DAG was not running, wait for it to initialise
+    if not args.reattach or dagmansleep:
         logger.debug("Sleep for 15 seconds while DAGMan starts up")
         sleep(15)
     # find lock file and monitor

--- a/omicron/condor.py
+++ b/omicron/condor.py
@@ -235,11 +235,12 @@ def get_dag_status(dagmanid, schedd=None, detailed=True):
             status['idle'] = 0
             nodes = schedd.query('DAGManJobId == %d' % dagmanid)
             for node in nodes:
-                if dict(node)['JobStatus'] == JOB_STATUS_MAP['held']:
+                s = get_job_status(node)
+                if s == JOB_STATUS_MAP['held']:
                     status['held'] += 1
-                elif dict(node)['JobStatus'] == JOB_STATUS_MAP['running']:
+                elif s == JOB_STATUS_MAP['running']:
                     status['running'] += 1
-                elif dict(node)['JobStatus'] == JOB_STATUS_MAP['idle']:
+                elif s == JOB_STATUS_MAP['idle']:
                     status['idle'] += 1
         return status
 
@@ -441,7 +442,7 @@ def find_dagman_id(group, classad="OmicronDAGMan", user=getuser(),
         raise RuntimeError("Multiple %s jobs found for group %r"
                            % (classad, group))
     clusterid = jobs[0]['ClusterId']
-    if jobs[0]['JobStatus'] >= 3:
+    if get_job_status(jobs[0]) >= 3:
         raise RuntimeError("DAGMan cluster %d found, but in state %r"
                            % JOB_STATUS[jobs[0]['JobStatus']])
     return clusterid

--- a/omicron/condor.py
+++ b/omicron/condor.py
@@ -29,6 +29,7 @@ from glob import glob
 from getpass import getuser
 
 import htcondor
+from classad import ClassAd
 
 import numpy
 
@@ -483,6 +484,31 @@ def dag_is_running(dagfile, group=None):
         else:
             return True
     return False
+
+
+def get_job_status(job, schedd=None):
+    """Get the status of a HTCondor process
+
+    Parameters
+    ----------
+    job : `str`, `classad.ClassAd`
+        either job ID (`str`, `int`, `float`) or a job object
+
+    schedd : `htcondor.Schedd`, optional
+        open scheduler connection
+
+    Returns
+    -------
+    status : `int`
+        the integer (`long`) status code for this job
+    """
+    if not isinstance(job, ClassAd):
+        # connect to scheduler
+        if schedd is None:
+            schedd = htcondor.Schedd()
+        # get status
+        job = list(schedd.query('ClusterId == %s' % job))[0]
+    return job['JobStatus']
 
 
 # -- custom jobs --------------------------------------------------------------

--- a/omicron/condor.py
+++ b/omicron/condor.py
@@ -448,7 +448,8 @@ def find_dagman_id(group, classad="OmicronDAGMan", user=getuser(),
     return clusterid
 
 
-def dag_is_running(dagfile, group=None):
+def dag_is_running(dagfile, group=None, classad="OmicronDAGMan",
+                   user=getuser()):
     """Return whether a DAG is running
 
     This method will return `True` if any of the following match
@@ -477,9 +478,9 @@ def dag_is_running(dagfile, group=None):
         return True
     if group is not None and os.path.isfile('%s.condor.sub' % dagfile):
         try:
-            find_dagman_id(group)
+            find_dagman_id(group, classad=classad, user=user)
         except RuntimeError as e:
-            if str(e).startswith('No %s' % group):
+            if str(e).startswith('No %s jobs' % classad):
                 return False
             raise
         else:


### PR DESCRIPTION
This PR modifies the `omicron-process` script to wait until the dagman process is in the 'running' state before attempting to watch it.

Also, fixed some bugs introduced by #35.