### PR TITLE
Added option to pad state segments

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -380,6 +380,21 @@ if statechannel:
     logger.debug("State bits = %s" % ', '.join(map(str, statebits)))
     logger.debug("State frametype = %s" % stateft)
 
+# parse padding for state segments
+if statechannel or stateflag:
+    try:
+        statepad = cp.get(group, 'state-padding')
+    except configparser.NoOptionError:
+        statepad = (0, 0)
+    else:
+        try:
+            p = int(statepad)
+        except ValueError:
+            statepad = map(float, statepad.split(',', 1))
+        else:
+            statepad = (p, p)
+    logger.debug("State padding: %s" % str(statepad))
+
 rundir = utils.get_output_directory(args)
 cachedir = os.path.join(rundir, 'cache')
 
@@ -494,10 +509,12 @@ if dataduration < chunkdur:
 if (online and statechannel) or (statechannel and not stateflag):
     logger.info("Finding segments for relevant state...")
     segs = segments.get_state_segments(statechannel, stateft,
-                                       datastart, dataend, bits=statebits)
+                                       datastart, dataend, bits=statebits,
+                                       pad=statepad)
 elif stateflag:
     logger.info("Querying segments for relevant state...")
-    segs = segments.query_state_segments(stateflag, datastart, dataend)
+    segs = segments.query_state_segments(stateflag, datastart, dataend,
+                                         pad=statepad)
 else:
     segs = segments.get_frame_segments(ifo, frametype, datastart, dataend)
 

--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -194,6 +194,10 @@ except configparser.NoOptionError:
     stateflag = None
 else:
     logger.debug("Parsed state flag: %r" % stateflag)
+    try:
+        statepad = map(float, cp.get(group, 'state-padding').split(','))
+    except configparser.NoOptionError:
+        statepad = (0, 0)
 
 logger.info("Processing %d-%d" % (start, end))
 
@@ -320,7 +324,7 @@ segs = segments.get_frame_segments(obs, frametype, start, end)
 
 # get state segments
 if stateflag is not None:
-    segs &= segments.query_state_segments(stateflag, start, end)
+    segs &= segments.query_state_segments(stateflag, start, end, pad=statepad)
 
 try:
     end = segs[-1][1]


### PR DESCRIPTION
This PR adds a new configuration option

```ini
state-padding = start, end
```

that can be used to contract state segments at either end, default is `0,0`. This might be useful for channels/groups that will go bananas when lock is lost.