### PR TITLE
Write segments.txt after workflow is submitted

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -855,13 +855,10 @@ elif newdag:
     logger.info("Dag with %d nodes written to" % len(dag.get_nodes()))
     print(os.path.abspath(dagfile))
 
-# write segments now
-# this means that online processing will _always_ move on, even if it fails
-if newdag:
-    segments.write_segments(span, segfile)
-    logger.info("Segments written to\n%s" % segfile)
-
 if args.no_submit:
+    if newdag:
+        segments.write_segments(span, segfile)
+        logger.info("Segments written to\n%s" % segfile)
     sys.exit(0)
 
 # -- submit the DAG and babysit -----------------------------------------------
@@ -894,6 +891,12 @@ for i in range(args.submit_rescue_dag + 1):
                 dagmanopts[key] = val
         dagid = condor.submit_dag(dagfile, *list(dagmanargs), **dagmanopts)
         logger.info("Condor ID = %d" % dagid)
+        # write segments now -- this means that online processing will
+        # _always_ move on even if the workflow fails
+        if i == 0:
+            segments.write_segments(span, segfile)
+            logger.info("Segments written to\n%s" % segfile)
+
     # wait for DAG to be in running state
     schedd = htcondor.Schedd()
     stat = condor.get_job_status(dagid, schedd)

--- a/omicron/condor.py
+++ b/omicron/condor.py
@@ -106,7 +106,7 @@ def submit_dag(dagfile, *arguments, **options):
         return int(re_dagman_cluster.search(out).group())
     except (AttributeError, IndexError, TypeError) as e:
         e.args = ('Failed to extract DAG cluster ID from '
-                  'condor_submit_dag output',)
+                  'condor_submit_dag output [%s]' % str(e),)
         raise
 
 


### PR DESCRIPTION
This PR modifies `omicron-process` to only write the `segments.txt` file if the workflow DAG gets submitted successfully. This means the processing will repeat if the DAG doesn't get submitted, which is good, but not if the DAG gets submitted and fails.