### PR TITLE
Improved JSON output for omicron-status

### DIFF
--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -562,22 +562,23 @@ for segset, tag in zip([gaps, overlap], ['gaps', 'overlap']):
     else:
         code = 0
         message = "No %s found in Omicron files for group %r" % (tag, group)
-    print_nagios_json(code, message, jsonfp, tag=tag)
+    print_nagios_json(code, message, jsonfp, tag=tag, **{tag: dict(chans)})
 
 # write group JSON
 jsonfp = os.path.join(outdir, 'nagios-latency-%s.json' % group)
 status.append(('latency', jsonfp))
 code = 0
 message = 'No channels have high latency for group %r' % group
+ldict = dict((c, max(latency[c].values())) for c in latency)
 for x, dt in zip([2, 1], [args.error, args.warning]):
     dh = dt / 3600.
-    chans = [c for c in latency if max(latency[c].values()) >= dh]
+    chans = [c for c in ldict if ldict[c] >= dh]
     if chans:
         code = x
         message = ("%d channels found with high latency (above %s seconds)"
                    % (len(chans), dt))
         break
-print_nagios_json(code, message, jsonfp, tag='latency')
+print_nagios_json(code, message, jsonfp, tag='latency', latency=ldict)
 
 # auto-detect 'standard' JSON files
 for tag, name in zip(

--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -216,7 +216,7 @@ logger.info("Processing %d-%d" % (start, end))
 
 # -- define nagios JSON printer -----------------------------------------------
 
-def print_nagios_json(code, message, outfile, tag='status'):
+def print_nagios_json(code, message, outfile, tag='status', **extras):
     out = {
         'created_gps': NOW,
         'status_intervals': [
@@ -243,6 +243,7 @@ def print_nagios_json(code, message, outfile, tag='status'):
             'version': __version__,
         },
     }
+    out.update(extras)
     with open(outfile, 'w') as f:
         f.write(json.dumps(out))
     logger.debug("nagios info written to %s" % outfile)


### PR DESCRIPTION
This PR modifies `omicron-status` to prints gaps, overlaps, and latency information to the JSON files in their own section, for machine readability.