### PR TITLE
Fixed two bugs in using llhoft frames at CIT

### DIFF
--- a/omicron/data.py
+++ b/omicron/data.py
@@ -301,4 +301,5 @@ def _find_ll_frames(ifo, frametype, root='/dev/shm'):
     obs = ifo[0]
     globstr = os.path.join(root, frametype, ifo,
                            '%s-%s_%s-*-*.gwf' % (obs, ifo, frametype))
-    return Cache.from_urls(glob.glob(globstr))
+    # don't return the last file, as it might not have been fully written yet
+    return Cache.from_urls(sorted(glob.glob(globstr)[:-1]))

--- a/omicron/data.py
+++ b/omicron/data.py
@@ -30,7 +30,7 @@ from glue import datafind
 from glue.lal import (Cache, CacheEntry)
 from glue.segments import (segment as Segment, segmentlist as SegmentList)
 
-re_ll = re.compile('\A[A-Z]\d_ll')
+re_ll = re.compile('\A[HL]1_ll')
 re_gwf_gps_epoch = re.compile('[-\/](?P<gpsepoch>\d+)$')
 
 


### PR DESCRIPTION
This PR fixes two small issues with using llhoft (low-latency h(t)) frames at CIT

- [0356b80] only match LIGO h(t) frames as using `/dev/shm`
- [9ee338b] don't read most recent llhoft frame, which may still be being written when it gets read (causing corruption problems)