### PR TITLE
Updated dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
-M2Crypto
+six
+pyOpenSSL
 pykerberos
-python-cjson
-http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
-http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
+lscsoft-glue
+dqsegdb
 gwpy


### PR DESCRIPTION
This PR updates the `requirements.txt` file to use the `lscsoft-glue` and `dqsegdb` packages available from pypi.python.org. This should let the CI for python-3.x get a bit further.