### PR TITLE
Fixed IndexError for no frames in data.find_frames

### DIFF
--- a/omicron/data.py
+++ b/omicron/data.py
@@ -208,11 +208,14 @@ def find_frames(obs, frametype, start, end, connection=None, **kwargs):
         # use latest frame to find more recent frames that aren't in
         # datafind yet, this is quite hacky, and isn't guaranteed to
         # work at any point, but it shouldn't break anything
-        latest = cache[-1]
+        try:
+            latest = cache[-1]
+        except IndexError:  # no frames
+            return cache
         try:
             ngps = len(re_gwf_gps_epoch.search(
                 os.path.dirname(latest.path)).groupdict()['gpsepoch'])
-        except AttributeError:
+        except AttributeError:  # no match
             pass
         else:
             while True:


### PR DESCRIPTION
This PR fixes an `IndexError` that occurs when no frames are returned by `datafind.find_frame_urls`.