### PR TITLE
Use h5 for file extension in omicron-status

### DIFF
--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -376,7 +376,7 @@ except ValueError:
     ends = []
 
 # load archive latency
-latencyfile = os.path.join(outdir, 'nagios-latency-%s.hdf' % tag)
+latencyfile = os.path.join(outdir, 'nagios-latency-%s.h5' % tag)
 times = dict((c, dict((ft, {}) for ft in filetypes)) for c in channels)
 ldata = dict((c, dict((ft, {}) for ft in filetypes)) for c in channels)
 if os.path.isfile(latencyfile):


### PR DESCRIPTION
This PR changes the file extension for the `nagios-latency-%(group)` file stored as part of `omicron-status`. `.h5` is a little more standard than `.hdf`.